### PR TITLE
Refactored generate_support, restricted typeguard

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,9 +6,10 @@
 2. Install virtual environment (the below example assumes conda)
 
     ```shell
-    conda create --name equine python>=3.10
+    conda create --name equine python==3.10
     conda activate equine
     ```
+    We currently support python versions >= 3.9
 
 3. Install the code with the extra `tests` dependencies
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
         "torchmetrics >= 0.6.0",
         "numpy",
         "tqdm",
-        "typeguard >= 3.0, <5.0",
+        "typeguard >= 3.0, <=4.0",
         "icontract",
         "scikit-learn",  # TODO: remove dependency on train_test_split
         "scipy",         # TODO: remove dependency on gaussian_kde

--- a/src/equine/__init__.py
+++ b/src/equine/__init__.py
@@ -19,7 +19,7 @@ from .utils import (
     generate_model_summary,
 )
 
-if not TYPE_CHECKING:
+if not TYPE_CHECKING:  # pragma: no cover
     try:
         from ._version import version as __version__
     except ImportError:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -40,7 +40,7 @@ def support_dataset(draw):
 
 
 @given(dataset=support_dataset())
-def test_generate_support(dataset) -> None:
+def test_generate_support(dataset):
     train_x, train_y, support_sz, tasks, _ = dataset
     eq.utils.generate_support(train_x, train_y, support_sz, tasks)
 


### PR DESCRIPTION
After merging #16, the tests began failing due to a typeguard error checking that a dictionary actually produces key, val pairs as a returned item in `generate_support` in `utils.py`. I used the opportunity to refactor that call to only ever return a dict by making it optional to pass in the shuffled indexes (only used internally in generate_episode, anyway), saving a second call to `torch.unique`. Upon finding an issue in typeguard that appeared at the same time as their upstream release and our error, I restricted the typeguard version to be 4.0 or lower.

Refs #17