### PR TITLE
Restricting numpy to 1.x for now

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ requires-python = ">=3.9"
 dependencies = [
         "torch >= 1.10.0",
         "torchmetrics >= 0.6.0",
-        "numpy",
+        "numpy < 2.0.0",
         "tqdm",
         "beartype",
         "icontract",


### PR DESCRIPTION
Noticed that, locally, there are some incompatibilities with numpy 2.0 that are causing test failures. Creating this branch to restrict numpy to 1.x on main and (then) to track/fix the issue later on.