### PR TITLE
Protonet fixes

### DIFF
--- a/src/equine/equine_protonet.py
+++ b/src/equine/equine_protonet.py
@@ -405,9 +405,6 @@ class Protonet(torch.nn.Module):
         embeddings = torch.cat(list(self.support_embeddings.values()))
         self.global_covariance = torch.unsqueeze(
             self.compute_covariance_by_type(OOD_COV_TYPE, embeddings), dim=0
-        global_reg_input = OrderedDict().fromkeys([0])
-        global_reg_input[0] = self.global_covariance
-        self.global_covariance = self.regularize_covariance(global_reg_input, OOD_COV_TYPE)[0]
         )
         global_reg_input = OrderedDict().fromkeys([0])
         global_reg_input[0] = self.global_covariance

--- a/src/equine/equine_protonet.py
+++ b/src/equine/equine_protonet.py
@@ -807,6 +807,7 @@ class EquineProtonet(Equine):
             "emb_out_dim": self.emb_out_dim,
             "use_temperature": self.use_temperature,
             "init_temperature": self.temperature.item(),
+            "relative_mahal": self.relative_mahal,
         }
 
         jit_model = torch.jit.script(self.model.embedding_model)  # type: ignore

--- a/src/equine/equine_protonet.py
+++ b/src/equine/equine_protonet.py
@@ -164,7 +164,9 @@ class Protonet(torch.nn.Module):
             )
             class_cov_dict[label] = class_covariance
 
-        reg_covariance_dict = self.regularize_covariance(class_cov_dict, cov_type, self.cov_reg_type)
+        reg_covariance_dict = self.regularize_covariance(
+            class_cov_dict, cov_type, self.cov_reg_type
+        )
         reg_covariance = torch.stack(list(reg_covariance_dict.values()))
 
         return reg_covariance  # TODO try putting everything on GPU with .to() and see if faster
@@ -189,7 +191,10 @@ class Protonet(torch.nn.Module):
         return class_covariance
 
     def regularize_covariance(
-        self, class_cov_dict: OrderedDict[int, torch.Tensor], cov_type: CovType, cov_reg_type: str
+        self,
+        class_cov_dict: OrderedDict[int, torch.Tensor],
+        cov_type: CovType,
+        cov_reg_type: str,
     ) -> OrderedDict[int, torch.Tensor]:
         """
         Method to add regularization to each class covariance matrix based on the selected regularization type.
@@ -408,7 +413,9 @@ class Protonet(torch.nn.Module):
         )
         global_reg_input = OrderedDict().fromkeys([0])
         global_reg_input[0] = self.global_covariance
-        self.global_covariance = self.regularize_covariance(global_reg_input, OOD_COV_TYPE, "epsilon")[0]
+        self.global_covariance = self.regularize_covariance(
+            global_reg_input, OOD_COV_TYPE, "epsilon"
+        )[0]
         self.global_mean = torch.mean(embeddings, dim=0)
 
 
@@ -671,7 +678,7 @@ class EquineProtonet(Equine):
             p_value = self.outlier_score_kde[int(predicted_class)].integrate_box_1d(
                 ood_dists[i].detach().numpy(), np.inf
             )
-            ood_scores[i] = 1.0 - np.clip(p_value,0.0,1.0)
+            ood_scores[i] = 1.0 - np.clip(p_value, 0.0, 1.0)
 
         return ood_scores
 

--- a/src/equine/equine_protonet.py
+++ b/src/equine/equine_protonet.py
@@ -405,6 +405,9 @@ class Protonet(torch.nn.Module):
         embeddings = torch.cat(list(self.support_embeddings.values()))
         self.global_covariance = torch.unsqueeze(
             self.compute_covariance_by_type(OOD_COV_TYPE, embeddings), dim=0
+        global_reg_input = OrderedDict().fromkeys([0])
+        global_reg_input[0] = self.global_covariance
+        self.global_covariance = self.regularize_covariance(global_reg_input, OOD_COV_TYPE)[0]
         )
         global_reg_input = OrderedDict().fromkeys([0])
         global_reg_input[0] = self.global_covariance

--- a/src/equine/equine_protonet.py
+++ b/src/equine/equine_protonet.py
@@ -7,6 +7,7 @@ from typing import Any, Callable
 
 import icontract
 import io
+import numpy as np
 import torch
 import warnings
 from beartype import beartype
@@ -17,7 +18,6 @@ from scipy.stats import gaussian_kde
 from sklearn.model_selection import train_test_split
 from torch.utils.data import TensorDataset
 from tqdm import tqdm
-import numpy as np
 
 from .equine import Equine, EquineOutput
 from .utils import (


### PR DESCRIPTION
Fixes a bug where the relative mahalanobis option is not saved when the model is saved.  So if you turn it off, then save and load, it will be back on by default and your OOD scores will be messed up.

Also added covariance regularization to the global covariance matrix