### PR TITLE
Features/pep585

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -19,7 +19,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        include:
+          - python-version: "3.13"
+            allow-failure: true
+    continue-on-error: ${{ matrix.allow-failure || false }}
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -20,10 +20,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        include:
-          - python-version: "3.13"
-            allow-failure: true
-    continue-on-error: ${{ matrix.allow-failure || false }}
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,9 +148,9 @@ python =
 
 
 [testenv]
-description = Runs test suite parallelized in the specified python enviornment and 
+description = Runs test suite parallelized in the specified python environment and 
               against number of available processes (up to 4). 
-              Run `tox -e py39 -- -n 0` to run tests in a python 3.9 with 
+              Run `tox -e py311 -- -n 0` to run tests in a python 3.11 with 
               parallelization disabled.
 passenv = *
 deps = pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,7 @@ legacy_tox_ini = """
 
 [tox]
 isolated_build = True
-envlist = py39, py310, py311, py312
+envlist = py39, py310, py311, py312, py313
 
 [gh-actions]
 python =
@@ -144,6 +144,7 @@ python =
   3.10: py310
   3.11: py311
   3.12: py312
+  3.13: py313
 
 
 [testenv]

--- a/src/equine/equine_gp.py
+++ b/src/equine/equine_gp.py
@@ -2,7 +2,7 @@
 # Subject to FAR 52.227-11 – Patent Rights – Ownership by the Contractor (May 2014).
 # SPDX-License-Identifier: MIT
 
-from typing import Any, Callable, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 import icontract
 import io
@@ -10,6 +10,7 @@ import math
 import torch
 from beartype import beartype
 from collections import OrderedDict
+from collections.abc import Callable
 from datetime import datetime
 from torch.utils.data import DataLoader, TensorDataset
 from tqdm import tqdm
@@ -17,7 +18,7 @@ from tqdm import tqdm
 from .equine import Equine, EquineOutput
 from .utils import generate_support, generate_train_summary, stratified_train_test_split
 
-BatchType = Tuple[torch.Tensor, ...]
+BatchType = tuple[torch.Tensor, ...]
 # -------------------------------------------------------------------------------
 # Note that the below code for
 # * `_random_ortho`,
@@ -296,7 +297,7 @@ class _Laplace(torch.nn.Module):
     @icontract.require(lambda self: self.training_parameters_set)
     def forward(
         self, x: torch.Tensor
-    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+    ) -> Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
         """
         Compute the forward pass of the Laplace approximation to the Gaussian Process.
 
@@ -307,7 +308,7 @@ class _Laplace(torch.nn.Module):
 
         Returns
         -------
-        Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
+        Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]
             If the model is in training mode, returns the predicted mean of shape (batch_size, 1).
             If the model is in evaluation mode, returns a tuple containing the predicted mean of shape (batch_size, 1)
             and the predicted covariance matrix of shape (batch_size, batch_size).

--- a/src/equine/equine_protonet.py
+++ b/src/equine/equine_protonet.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 from __future__ import annotations
 
-from typing import Any, Callable, Optional
+from typing import Any, Optional
 
 import icontract
 import io
@@ -12,6 +12,7 @@ import torch
 import warnings
 from beartype import beartype
 from collections import OrderedDict
+from collections.abc import Callable
 from datetime import datetime
 from enum import Enum
 from scipy.stats import gaussian_kde
@@ -387,7 +388,7 @@ class Protonet(torch.nn.Module):
         Returns
         -------
         tuple[torch.Tensor, torch.Tensor]
-            Tuple containing class probability predictions, and class distances from prototypes.
+            tuple containing class probability predictions, and class distances from prototypes.
         """
         if len(self.support) == 0 or len(self.support_embeddings) == 0:
             raise ValueError(

--- a/src/equine/utils.py
+++ b/src/equine/utils.py
@@ -2,7 +2,7 @@
 # Subject to FAR 52.227-11 – Patent Rights – Ownership by the Contractor (May 2014).
 # SPDX-License-Identifier: MIT
 
-from typing import Any, List, Tuple, Union
+from typing import Any, Union
 
 import icontract
 import torch
@@ -107,7 +107,7 @@ def expected_calibration_error(y_hat: torch.Tensor, y_test: torch.Tensor) -> flo
 )
 @beartype
 def _get_shuffle_idxs_by_class(
-    train_y: torch.Tensor, selected_labels: List
+    train_y: torch.Tensor, selected_labels: list
 ) -> dict[Any, torch.Tensor]:
     """
     Internal helper function to randomly select indices of example classes for a given
@@ -117,8 +117,8 @@ def _get_shuffle_idxs_by_class(
     ----------
     train_y : torch.Tensor
         Label data.
-    selected_labels : List
-        List of unique labels found in the label data.
+    selected_labels : list
+        list of unique labels found in the label data.
 
     Returns
     -------
@@ -160,7 +160,7 @@ def generate_support(
     train_x: torch.Tensor,
     train_y: torch.Tensor,
     support_size: int,
-    selected_labels: List[Any],
+    selected_labels: list[Any],
     shuffled_indexes: Union[None, dict[Any, torch.Tensor]] = None,
 ) -> OrderedDict[int, torch.Tensor]:
     """
@@ -175,7 +175,7 @@ def generate_support(
         Corresponding classification labels.
     support_size : int
         Number of support examples for each class.
-    selected_labels : List
+    selected_labels : list
         Selected class labels to generate examples from.
     shuffled_indexes: Union[None, dict[Any, torch.Tensor]], optional
         Simply use the precomputed indexes if they are available
@@ -227,7 +227,7 @@ def generate_episode(
     support_size: int,
     way: int,
     episode_size: int,
-) -> Tuple[OrderedDict[int, torch.Tensor], torch.Tensor, torch.Tensor]:
+) -> tuple[OrderedDict[int, torch.Tensor], torch.Tensor, torch.Tensor]:
     """
     Generate a single episode of data for a few-shot learning task.
 
@@ -246,8 +246,8 @@ def generate_episode(
 
     Returns
     -------
-    Tuple[dict[Any, torch.Tensor], torch.Tensor, torch.Tensor]
-        Tuple of support examples, query examples, and query labels.
+    tuple[dict[Any, torch.Tensor], torch.Tensor, torch.Tensor]
+        tuple of support examples, query examples, and query labels.
     """
     labels, counts = torch.unique(train_y, return_counts=True)
     if way > len(labels):
@@ -347,7 +347,7 @@ def generate_model_metrics(
 )
 @icontract.ensure(lambda result: all(d["numExamples"] >= 0 for d in result))
 @beartype
-def get_num_examples_per_label(Y: torch.Tensor) -> List[dict[str, Any]]:
+def get_num_examples_per_label(Y: torch.Tensor) -> list[dict[str, Any]]:
     """
     Get the number of examples per label in the given tensor.
 
@@ -358,8 +358,8 @@ def get_num_examples_per_label(Y: torch.Tensor) -> List[dict[str, Any]]:
 
     Returns
     -------
-    List[dict[str, Any]]
-        List of dictionaries containing label and number of examples.
+    list[dict[str, Any]]
+        list of dictionaries containing label and number of examples.
     """
     tensor_labels, tensor_counts = Y.unique(return_counts=True)
 
@@ -485,7 +485,7 @@ def mahalanobis_distance_nosq(x: torch.Tensor, cov: torch.Tensor) -> torch.Tenso
 @beartype
 def stratified_train_test_split(
     X: torch.Tensor, Y: torch.Tensor, test_size: float
-) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     A pytorch-ified version of sklearn's train_test_split with data stratification
 


### PR DESCRIPTION
A number of classes in the `typing` module are deprecated and will be removed later this year (Tuple, List, Dict, etc.). This PR aims to remove the deprecation warnings emitted by beartype in anticipation of their removal. 