### PR TITLE
Add support for Python 3.14, remove 3.9 (EOL)

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
     - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -9,7 +9,7 @@
     conda create --name equine python==3.11
     conda activate equine
     ```
-    We currently support python versions >= 3.9
+    We currently support python versions from 3.10 to 3.14
 
 3. Install the code with the extra `tests` dependencies
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ maintainers = [
 ]
 description = "EQUINE^2: Establishing Quantified Uncertainty for Neural Networks"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
         "torch >= 1.10.0, < 2.3.0 ; platform_machine == 'x86_64' and sys_platform == 'darwin'",
         "torch >= 2.0.0, < 2.10.0 ; platform_machine != 'x86_64' or sys_platform != 'darwin'",
@@ -136,15 +136,15 @@ legacy_tox_ini = """
 
 [tox]
 isolated_build = True
-envlist = py39, py310, py311, py312, py313
+envlist = py310, py311, py312, py313, py314
 
 [gh-actions]
 python =
-  3.9: py39
   3.10: py310
   3.11: py311
   3.12: py312
   3.13: py313
+  3.14: py314
 
 
 [testenv]

--- a/src/equine/equine_gp.py
+++ b/src/equine/equine_gp.py
@@ -17,7 +17,7 @@ from torchmetrics.metric import Metric
 from tqdm import tqdm
 
 from .equine import Equine, EquineOutput
-from .utils import generate_support, generate_train_summary
+from .utils import generate_support, generate_train_summary, prepare_jit_module
 
 BatchType = tuple[torch.Tensor, ...]
 # -------------------------------------------------------------------------------
@@ -769,7 +769,7 @@ class EquineGP(Equine):
             "device": self.device_type,
         }
 
-        jit_model = torch.jit.script(self.model.feature_extractor)
+        jit_model = torch.jit.script(prepare_jit_module(self.model.feature_extractor))
         buffer = io.BytesIO()
         torch.jit.save(jit_model, buffer)
         buffer.seek(0)

--- a/src/equine/equine_protonet.py
+++ b/src/equine/equine_protonet.py
@@ -25,6 +25,7 @@ from .utils import (
     generate_support,
     generate_train_summary,
     mahalanobis_distance_nosq,
+    prepare_jit_module,
     stratified_train_test_split,
 )
 
@@ -906,7 +907,7 @@ class EquineProtonet(Equine):
             "device": self.device,
         }
 
-        jit_model = torch.jit.script(self.model.embedding_model)
+        jit_model = torch.jit.script(prepare_jit_module(self.model.embedding_model))
         buffer = io.BytesIO()
         torch.jit.save(jit_model, buffer)
         buffer.seek(0)

--- a/src/equine/utils.py
+++ b/src/equine/utils.py
@@ -20,6 +20,7 @@ from .equine import Equine
 from .equine_output import EquineOutput
 
 
+@icontract.ensure(lambda result, module: result is module)
 @beartype
 def prepare_jit_module(module: torch.nn.Module) -> torch.nn.Module:
     """

--- a/src/equine/utils.py
+++ b/src/equine/utils.py
@@ -5,6 +5,7 @@
 from typing import Any, Union
 
 import icontract
+import sys
 import torch
 from beartype import beartype
 from collections import OrderedDict
@@ -17,6 +18,41 @@ from torchmetrics.classification import (
 
 from .equine import Equine
 from .equine_output import EquineOutput
+
+
+@beartype
+def prepare_jit_module(module: torch.nn.Module) -> torch.nn.Module:
+    """
+    Make an ``nn.Module`` safe to pass to ``torch.jit.script`` on Python 3.14+.
+
+    Starting with Python 3.14 (PEP 649/749) a class's ``__annotations__`` is
+    exposed through a ``type`` getset descriptor instead of being stored in the
+    class ``__dict__``. ``torch.jit``'s scripting checker reads
+    ``__annotations__`` from the module *instance*, where attribute lookup only
+    consults the ``__dict__`` of each class in the MRO. For any ``nn.Module``
+    that declares no class-level annotations this lookup misses and
+    ``nn.Module.__getattr__`` raises ``AttributeError``, breaking
+    ``torch.jit.script``. Materializing each submodule's own class annotations
+    onto its instance ``__dict__`` lets that lookup succeed. This is a no-op on
+    Python < 3.14.
+
+    Parameters
+    ----------
+    module : torch.nn.Module
+        The module that is about to be scripted with ``torch.jit.script``.
+
+    Returns
+    -------
+    torch.nn.Module
+        The same module, returned for convenient inline use.
+    """
+    if sys.version_info >= (3, 14):
+        for submodule in module.modules():
+            if "__annotations__" not in submodule.__dict__:
+                submodule.__dict__["__annotations__"] = dict(
+                    type(submodule).__annotations__
+                )
+    return module
 
 
 @icontract.require(lambda y_hat, y_test: y_hat.size(dim=0) == y_test.size(dim=0))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,22 @@ from hypothesis import given, settings, strategies as st
 import equine as eq
 
 
+class _NoAnnotationModel(torch.nn.Module):
+    """An nn.Module that declares no class-level annotations.
+
+    On Python 3.14 such a module cannot be passed to ``torch.jit.script``
+    without ``prepare_jit_module`` first materializing its instance
+    ``__annotations__`` (see PEP 649/749).
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear = torch.nn.Linear(4, 2)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.linear(x)
+
+
 @st.composite
 def support_dataset(draw):
     support_sz = draw(st.integers(min_value=2, max_value=25))
@@ -208,3 +224,16 @@ def test_stratified_split_imbalanced_classes():
 
     assert torch.all(actual_train_counts == expected_train_counts)
     assert torch.all(actual_test_counts == expected_test_counts)
+
+
+def test_prepare_jit_module_makes_module_scriptable():
+    # Regression test for Python 3.14 (PEP 649/749): a module with no
+    # class-level annotations must remain compatible with torch.jit.script
+    # after prepare_jit_module, which is what EquineGP/EquineProtonet.save use.
+    model = _NoAnnotationModel()
+    returned = eq.utils.prepare_jit_module(model)
+    assert returned is model  # returned for convenient inline use
+
+    scripted = torch.jit.script(model)  # must not raise on Python 3.14
+    x = torch.rand(8, 4)
+    assert torch.allclose(scripted(x), model(x))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,9 +20,9 @@ class _NoAnnotationModel(torch.nn.Module):
     ``__annotations__`` (see PEP 649/749).
     """
 
-    def __init__(self) -> None:
+    def __init__(self, in_dim: int, out_dim: int) -> None:
         super().__init__()
-        self.linear = torch.nn.Linear(4, 2)
+        self.linear = torch.nn.Linear(in_dim, out_dim)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.linear(x)
@@ -226,14 +226,20 @@ def test_stratified_split_imbalanced_classes():
     assert torch.all(actual_test_counts == expected_test_counts)
 
 
-def test_prepare_jit_module_makes_module_scriptable():
+@given(
+    in_dim=st.integers(min_value=1, max_value=16),
+    out_dim=st.integers(min_value=1, max_value=16),
+    batch=st.integers(min_value=1, max_value=8),
+)
+@settings(deadline=None, max_examples=5)
+def test_prepare_jit_module_makes_module_scriptable(in_dim, out_dim, batch):
     # Regression test for Python 3.14 (PEP 649/749): a module with no
     # class-level annotations must remain compatible with torch.jit.script
     # after prepare_jit_module, which is what EquineGP/EquineProtonet.save use.
-    model = _NoAnnotationModel()
+    model = _NoAnnotationModel(in_dim, out_dim)
     returned = eq.utils.prepare_jit_module(model)
     assert returned is model  # returned for convenient inline use
 
     scripted = torch.jit.script(model)  # must not raise on Python 3.14
-    x = torch.rand(8, 4)
+    x = torch.rand(batch, in_dim)
     assert torch.allclose(scripted(x), model(x))


### PR DESCRIPTION
## Summary

Adds Python 3.14 to the CI matrix + tox environments and drops end-of-life Python 3.9 (`requires-python` → `>=3.10`). This revives the work in #138, which got stuck on a failing `tests (3.14)` job.

## Why #138's 3.14 job failed

The blocker is **not** a dependency-version issue — it's a Python 3.14 change to how annotations are stored (PEP 649 / PEP 749).

`EquineGP.save` / `EquineProtonet.save` serialize the embedding/feature-extractor module with `torch.jit.script`. On Python 3.14, that fails:

```
AttributeError: 'BasicEmbeddingModel' object has no attribute '__annotations__'
```

Root cause: on 3.14 a class's `__annotations__` is exposed through a `type` getset descriptor instead of being stored in the class `__dict__`. But `torch.jit`'s scripting checker (`torch/jit/_check.py`) reads `__annotations__` from the module **instance**. Instance attribute lookup only consults each MRO class's `__dict__`, so for any `nn.Module` that declares no class-level annotations the lookup misses and `nn.Module.__getattr__` raises `AttributeError`. This affects any user model, not just the test fixtures. Only the 7 `save_load` tests were affected; the rest of the suite already passed on 3.14. The bug is upstream in torch and is still present on torch `main`, so bumping the torch pin alone does not resolve it.

## Fix

A small helper, `utils.prepare_jit_module`, materializes each submodule's own class annotations onto its instance `__dict__` right before scripting, so torch's instance-level lookup resolves. It is a **no-op on Python < 3.14** and does not monkeypatch torch internals. Both `save()` paths now call it.

## Verification

- All 36 tests pass on Python 3.14 (previously 7 `save_load` failures); save/load round-trips remain numerically identical (`mse_loss ≤ 1e-7`).
- `black`, `isort`, `flake8`, and `codespell` all clean.

## Changes
- `src/equine/utils.py`: add `prepare_jit_module`
- `src/equine/equine_gp.py`, `src/equine/equine_protonet.py`: wrap the scripted module
- `.github/workflows/Tests.yml`, `pyproject.toml`: matrix/tox `3.9`→`3.14`, `requires-python` `>=3.10`
- `docs/CONTRIBUTING.md`: supported-version note