### PR TITLE
docs: offer uv as an alternative dev-environment setup

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -3,18 +3,32 @@
 ## Developer Installation 
 1. Clone the [git repository](https://github.com/mit-ll-responsible-ai/equine) and navigate to that directory
     
-2. Install virtual environment (the below example assumes conda)
+2. Install a virtual environment. We currently support python versions from 3.10 to 3.14.
+
+    Using conda:
 
     ```shell
     conda create --name equine python==3.11
     conda activate equine
     ```
-    We currently support python versions from 3.10 to 3.14
+
+    Or, alternatively, using [uv](https://docs.astral.sh/uv/):
+
+    ```shell
+    uv venv --python 3.11
+    source .venv/bin/activate
+    ```
 
 3. Install the code with the extra `tests` dependencies
 
     ```shell
     pip install -e .'[tests]'
+    ```
+
+    If you created the environment with uv, you can use `uv pip` instead:
+
+    ```shell
+    uv pip install -e '.[tests]'
     ```
 
 4. Activate the pre-commit hooks


### PR DESCRIPTION
Implements part 1 of #150: documents `uv` as an alternative to conda in the Developer Installation section of `docs/CONTRIBUTING.md`.

Per the maintainer request on #150 to land the two suggestions as separate PRs in order, this is the first (docs only). The `tox-uv` CI change will follow in a separate PR.

### What changed
- Added a `uv venv` / `source .venv/bin/activate` example alongside the existing conda environment step.
- Added a `uv pip install -e '.[tests]'` alternative alongside the existing `pip install` step.

### Why it's safe
Purely additive. The underlying `pip install -e '.[tests]'` workflow is unchanged, so conda users are unaffected. No dependency, build, or CI changes.

Closes part 1 of #150.