### PR TITLE
ci: use tox-uv as the tox installer backend

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install tox
       run: |
         python -m pip install --upgrade pip
-        python -m pip install tox tox-gh-actions
+        python -m pip install tox tox-uv tox-gh-actions
     - name: Test with tox
       run: tox -e py
 
@@ -44,7 +44,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox
+        pip install tox tox-uv
     - name: Measure coverage
       run: tox -e coverage
 
@@ -59,7 +59,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions
+        pip install tox tox-uv tox-gh-actions
     - name: Test with tox
       run: tox -e enforce-format
 
@@ -74,7 +74,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions
+        pip install tox tox-uv tox-gh-actions
     - name: Test with tox
       run: tox -e docs
       env:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -23,7 +23,12 @@
     pre-commit run
     ```
 
-5. For local testing, install tox (`pip install tox`)
+5. For local testing, install tox (`pip install tox`).
+
+    Optionally, also install [`tox-uv`](https://github.com/tox-dev/tox-uv)
+    (`pip install tox tox-uv`) to have tox use `uv` to build its environments
+    and install dependencies. This is drop-in (no tox config changes) and
+    significantly faster — it's the same backend CI uses.
 
 
 We prefer that any contributed code be outfitted with contracts from `icontract` and tested with `hypothesis`. 


### PR DESCRIPTION
Implements part 2 of #150: speeds up the CI test matrix by letting `tox` use `uv` as its environment/installer backend via the `tox-uv` plugin.

Follows the docs PR (#154) as the second of the two PRs requested on #150.

### What changed
- Added `tox-uv` to the `pip install` step of each CI job in `.github/workflows/Tests.yml` (`tests` matrix, `coverage`, `check-repo-format`, `test-docs-builds`).
- Added a short note to `docs/CONTRIBUTING.md` documenting `tox-uv` as an optional, faster local tox backend, so contributors can opt into the same uv-backed runs CI uses.

### Why it's drop-in / safe
- No changes to the tox configuration — `legacy_tox_ini`, `basepython`, and all dependency ranges are untouched. Once `tox-uv` is installed, tox automatically uses `uv` to build envs and install deps.
- No `uv.lock` committed and no change to `pyproject.toml` ranges, so end-user installs and the library's supported version ranges are unaffected.
- Fully reversible — drop `tox-uv` from the install steps and tox reverts to the virtualenv/pip backend.

### Validation
This PR's own CI is the real-world proof: all 8 jobs (the 3.10-3.14 matrix, `coverage`, `check-repo-format`, `test-docs-builds`) pass on GitHub's runners with tox-uv.

Locally (macOS/arm64) all affected envs also run green against `main`:
- `py314`: 37/37 passed (uv auto-provisioned the 3.14 interpreter)
- `coverage`: 37/37 passed, coverage >=97%
- `enforce-format`: ruff format/check + codespell all clean
- `docs`: mkdocs `--strict` build succeeded

### Benchmark (single `py314` env, isolated caches, env-setup time)
| Cache state | pip + virtualenv | tox-uv | Speedup |
|-------------|------------------|--------|---------|
| Cold        | ~31 s            | ~7.5 s | ~4x     |
| Warm        | ~27 s            | ~3.8 s | ~7x     |

Absolute times differ from the figures in #150 (network/machine variance), but the speedup multiples reproduce. GitHub runners are cold per job, so the ~4x cold figure is the representative one; adding a uv-cache step later could push individual jobs toward the warm number.

Closes part 2 of #150.